### PR TITLE
Add Dash beta after removal from homebrew-versions

### DIFF
--- a/Casks/dash-beta.rb
+++ b/Casks/dash-beta.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'dash-beta' do
+  version '2.3.0'
+  sha256 '5434eb1eb8a1429d4e1e6bcdb5b76a7b5930ceab1bbd94f41cb6a41e454e7512'
+
+  # cloudfront.net is the official download host per the vendor homepage
+  url 'https://dl0tgz6ee3upo.cloudfront.net/production/app/builds/004/633/802/original/537af3eefba4513c44aedbab7606c3bf/Dash_Beta.app.zip'
+  homepage 'http://kapeli.com/dash'
+  license :commercial
+
+  app 'Dash Beta.app'
+end


### PR DESCRIPTION
This cask was removed from the caskroom/homebrew-versions repo as the
beta download link is held behind a login page on HockeyApp.

I've also updated it from the version in homebrew-versions so that
it is now referencing 2.3.0