### PR TITLE
Create dock-dodger.rb

### DIFF
--- a/Casks/dock-dodger.rb
+++ b/Casks/dock-dodger.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'dock-dodger' do
+  version '0.1'
+  sha256 '0dd4c4956d2fe0b223cd84cdeca8f82ffc51bf90ebdd0fb599c61459dfba2eeb'
+
+  url 'http://dl.macupdate.com/prod/Dock%20Dodger.zip'
+  name 'Dock Dodger'
+  homepage 'http://foggynoggin.com'
+  license :unknown
+
+  app 'Dock Dodger.app'
+end


### PR DESCRIPTION
An old app (left from 2007) that still works with 10.11.
It removes Dock icon from the apps, as advertised. Only link
to the app is on MacUpdates.