### PR TITLE
Add WCH CH34x USB Serial driver

### DIFF
--- a/Casks/wch-ch34x-usb-serial-driver-unofficial.rb
+++ b/Casks/wch-ch34x-usb-serial-driver-unofficial.rb
@@ -1,0 +1,23 @@
+cask 'wch-ch34x-usb-serial-driver-unofficial' do
+  version '1.0'
+  sha256 '47eaff5aeaa70fdc507f0772f3b87fdd6348ada300de8a1ad7c38d53d185fc0b'
+
+  url 'https://raw.githubusercontent.com/kiguino/kiguino.github.io/master/downloads/CH34x_Install.zip'
+  name 'WCH USB serial driver for CH340/CH341 (unofficial release)'
+  homepage ''
+  license :gratis
+
+  caveats <<-EOS.undent
+    Warning: This driver was not officially published and its source is
+    unclear. Discussion:
+    https://github.com/caskroom/homebrew-unofficial/pull/55
+  EOS
+
+  container :type => :zip,
+            :nested => 'CH34x_Install.pkg'
+
+  pkg 'CH34x_Install.pkg'
+
+  uninstall :pkgutil => 'com.wch.usbserial.pkg',
+            :kext => 'com.wch.usbserial'
+end


### PR DESCRIPTION
**Note**: This is *not* the driver found on [wch.cn](http://www.wch.cn/download/CH341SER_MAC_ZIP.html), which has pkg identifier `com.wch.ch34xinstall.usb.pkg` and has a `v1.1.1` release (at least), but is unsigned and thus does not work with Yosemite or El Capitan (unless kext signature checks are disabled).

This driver has pkg ID `com.wch.usbserial.pkg`, appears to be developed by the same company (but who knows), and has version `v1.0`. It was published on [a blog](http://blog.sengotta.net/signed-mac-os-driver-for-winchiphead-ch340-serial-bridge/) (unrelated to the company), and later [linked on another](http://kiguino.moos.io/2014/12/31/how-to-use-arduino-nano-mini-pro-with-CH340G-on-mac-osx-yosemite.html) which gives a nice summary of various versions.

*As such it should be treated as untrustworthy and potentially harmful to your system.*

-----

(continued from caskroom/homebrew-cask#15753)

Here's the never-officially-released signed version of the WCH 340/341 USB Serial driver.
The cask needs testing and maybe a better name. Both install and uninstall work fine for me on El Capitan 10.11.2.

(I’ll remove the comments once we determine that the cask itself is fine.)